### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
-  before_action :set_item, only: [:show]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :move_to_edit, only: [:edit, :update]
+  before_action :set_select_values, only: [:new, :create, :edit, :update]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -8,11 +10,6 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
-    @categories = Category.all
-    @conditions = Condition.all
-    @shipping_fees = ShippingFee.all
-    @prefectures = Prefecture.all
-    @delivery_times = DeliveryTime.all
   end
 
   def create
@@ -20,16 +17,22 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
-      @categories = Category.all
-      @conditions = Condition.all
-      @shipping_fees = ShippingFee.all
-      @prefectures = Prefecture.all
-      @delivery_times = DeliveryTime.all
       render :new, status: :unprocessable_entity
     end
   end
 
   def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private
@@ -40,5 +43,16 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
-  
+
+  def move_to_edit
+    redirect_to root_path unless @item.user == current_user
+  end
+
+  def set_select_values
+    @categories = Category.all
+    @conditions = Condition.all
+    @shipping_fees = ShippingFee.all
+    @prefectures = Prefecture.all
+    @delivery_times = DeliveryTime.all
+  end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,151 +1,128 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
-
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
+      <%= render 'shared/error_messages', model: f.object %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+      <div class="img-upload">
+        <div class="weight-bold-text">
+          商品画像
+          <span class="indispensable">必須</span>
+        </div>
+        <div class="click-upload">
+          <p>
+            クリックしてファイルをアップロード
+          </p>
+          <%= f.file_field :image, id:"item-image" %>
+        </div>
+      </div>
 
-    <%# 商品画像 %>
-    <div class="img-upload">
-      <div class="weight-bold-text">
-        商品画像
-        <span class="indispensable">必須</span>
-      </div>
-      <div class="click-upload">
-        <p>
-          クリックしてファイルをアップロード
-        </p>
-        <%= f.file_field :hoge, id:"item-image" %>
-      </div>
-    </div>
-    <%# /商品画像 %>
-    <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <div class="items-explain">
+      <div class="new-items">
         <div class="weight-bold-text">
-          商品の説明
+          商品名
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
-      </div>
-    </div>
-    <%# /商品名と商品説明 %>
+        <%= f.text_area :product, class: "items-text", id: "item-name", placeholder: "商品名（必須 40文字まで)", maxlength: "40" %>
 
-    <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
-        <div class="weight-bold-text">
-          カテゴリー
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
-    </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
-    </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
+        <div class="items-explain">
+          <div class="weight-bold-text">
+            商品の説明
             <span class="indispensable">必須</span>
           </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
-        </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
-        </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
-          </span>
+          <%= f.text_area :description, class: "items-text", id: "item-info", placeholder: "商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
         </div>
       </div>
-    </div>
-    <%# /販売価格 %>
 
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
-    </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
-    </div>
-    <%# /下部ボタン %>
+          <div class="items-detail">
+        <div class="weight-bold-text">商品の詳細</div>
+        <div class="form">
+          <div class="weight-bold-text">
+            カテゴリー
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:category_id, @categories, :id, :name, {}, { class: "select-box", id: "item-category" }) %>
+
+          <div class="weight-bold-text">
+            商品の状態
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:condition_id, @conditions, :id, :name, {}, { class: "select-box", id: "item-sales-status" }) %>
+        </div>
+      </div>
+
+      <div class="items-detail">
+        <div class="weight-bold-text question-text">
+          <span>配送について</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div class="form">
+          <div class="weight-bold-text">
+            配送料の負担
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:shipping_fee_id, @shipping_fees, :id, :name, {}, { class: "select-box", id: "item-shipping-fee-status" }) %>
+
+          <div class="weight-bold-text">
+            発送元の地域
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:prefecture_id, @prefectures, :id, :name, {}, { class: "select-box", id: "item-prefecture" }) %>
+
+          <div class="weight-bold-text">
+            発送までの日数
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:delivery_time_id, @delivery_times, :id, :name, {}, { class: "select-box", id: "item-scheduled-delivery" }) %>
+        </div>
+      </div>
+
+      <div class="sell-price">
+        <div class="weight-bold-text question-text">
+          <span>販売価格<br>(¥300〜9,999,999)</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div>
+          <div class="price-content">
+            <div class="price-text">
+              <span>価格</span>
+              <span class="indispensable">必須</span>
+            </div>
+            <span class="sell-yen">¥</span>
+            <%= f.text_field :price, class: "price-input", id: "item-price", placeholder: "例）300" %>
+          </div>
+            <div class="price-content">
+              <span>販売手数料 (10%)</span>
+              <span><span id="add-tax-price"></span>円</span>
+            </div>
+          <div class="price-content">
+            <span>販売利益</span>
+            <span><span id="profit"></span>円</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="caution">
+        <p class="sentence">
+          <a href="#">禁止されている出品、</a><a href="#">行為</a>を必ずご確認ください。
+        </p>
+        <p class="sentence">
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          <a href="#">偽ブランドの販売</a>は犯罪であり処罰される可能性があります。
+        </p>
+        <p class="sentence">
+          また、出品をもちまして<a href="#">加盟店規約</a>に同意したことになります。
+        </p>
+      </div>
+
+      <div class="sell-btn-contents">
+        <%= f.submit "変更する", class: "sell-btn" %>
+        <%= link_to 'もどる', item_path(@item), class: "back-btn" %>
+      </div>
+    <% end %>
   </div>
-  <% end %>
 
   <footer class="items-sell-footer">
     <ul class="menu">
@@ -153,9 +130,7 @@ app/assets/stylesheets/items/new.css %>
       <li><a href="#">フリマ利用規約</a></li>
       <li><a href="#">特定商取引に関する表記</a></li>
     </ul>
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-    <p class="inc">
-      ©︎Furima,Inc.
-    </p>
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
+    <p class="inc">©︎Furima,Inc.</p>
   </footer>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>


### PR DESCRIPTION
# What
商品情報編集機能の作成

# Why
商品情報編集機能を実装しました。

【　確認用度動画　】
・ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/5488ed43f4e45b3625cd86efd5216ad0

・必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/ccb853072383d80d0992d62348c6ec19

・入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/2858ae98b054539c58a1058d47e19354

・何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/4bbd1ac87b061b4c364f9c1b35393eda

・ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/9238dd6ff27209a6bff40870276a4c85

・ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
購入機能が未実装のため無し

・ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/7c342c8c436eb9be0be3d19bfe0e6943

・商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い
https://gyazo.com/2f4c5beef4b20d116be40323f2fd65f4